### PR TITLE
removed the script, and instead added procfile to add npm run build

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run build && npm run start

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "cypress": "cypress open",
-    "eject": "react-scripts eject",
-    "heroku-postbuild": "NPM_CONFIG_PRODUCTION=false npm install --prefix frontend && npm run build --prefix frontend"
+    "eject": "react-scripts eject"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Type of Change
- [x] testing 🧪


## Description
Hoping to solve the current issues that we are experiencing with our deployment, where our current project is 250% over memory usage. The deployed site is operating with npm start, instead of build, hoping the procfile will change the code version to operate in a production mode
