### PR TITLE
Feat/open email from contact page

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ User Context has been implemented!! The use case for the context is getting acce
 
 ### Right up front, here is a guide for implementation:
 
-**$\text{\color{#f23030}PRE REQS:}$** $\text{\color{#f28730}The only requirement is that your component is being proprerly rendered in 'App.tsx' so make sure to check that first.}$
+**$\text{\color{#f23030}PRE REQS:}$** $\text{\color{#f28730}The only requirement is that your component is being properly rendered in 'App.tsx' so make sure to check that first.}$
 
 1. Import useUserLoggedContext into your component page:
    - $\text{\color{#9d7af5} import}\text{\color{#f5e97a} \\{ }\text{\color{#7adef5}useUserLoggedContext}\text{\color{#f5e97a} \\}}\text{\color{#9d7af5} from}\text{\color{#fca944} './context/UserLoggedContext.tsx'}$;
@@ -481,7 +481,7 @@ Use the search bar to quickly find companies by name, enhancing efficiency and u
 ![Companies Section Demo](public/assets/companies.gif)
 
 
-### Feature 4 - Contacts
+### Feature 5 - Contacts
 
 The Contacts section allows users to navigate their contacts.
 
@@ -490,7 +490,7 @@ Key Functionalities Include:
 - View All Contacts:
 Browse a comprehensive list of contacts with info like their name, company, and notes. Includes a search bar and ability to create a new contact.
 - View a Contact:
-Click on  a contact to see detail info on a dedicated page, such as their name, company, email address, phone number, notes and any other contacts associated with the company. Click on the other contacts to view their contact page.
+Click on  a contact to see detail info on a dedicated page, such as their name, company, email address, phone number, notes and any other contacts associated with the company. Click on the other contacts to view their contact page. Click the contact's email address to open their mail client with an email to the contact.
 - Add a new Contact
 Click on the Add New + button to navigate to a form where a user inputs a new contact and their associated information.
 - Search for a Contact
@@ -500,7 +500,7 @@ Use the search bar to quickly find a contact by name, enhancing efficiency and u
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-### Feature 5 - Job Applications
+### Feature 6 - Job Applications
 
 - View All Job Applications:
 

--- a/cypress/e2e/ShowContactSpec.cy.js
+++ b/cypress/e2e/ShowContactSpec.cy.js
@@ -124,6 +124,7 @@ describe("Show a single contact page", () => {
     cy.wait("@get-contact-details");
     cy.get('[data-testid="contact-email"]').should("have.text", "Email: ");
     cy.get('[data-testid="email-address"]').should("have.text", "123@example.com");
+    cy.get('[data-testid="email-address"]').should("have.text", "123@example.com");
     cy.get('[data-testid="contact-phone"]').should("have.text", "Phone: ");
     cy.get('[data-testid="phone-num"]').should("have.text", "123-555-6789");
   });

--- a/cypress/e2e/ShowContactSpec.cy.js
+++ b/cypress/e2e/ShowContactSpec.cy.js
@@ -124,7 +124,7 @@ describe("Show a single contact page", () => {
     cy.wait("@get-contact-details");
     cy.get('[data-testid="contact-email"]').should("have.text", "Email: ");
     cy.get('[data-testid="email-address"]').should("have.text", "123@example.com");
-    cy.get('[data-testid="email-address"]').should("have.text", "123@example.com");
+    cy.get('[data-testid="email-address"]').should('have.attr', 'href').and('include', 'mailto:123@example.com')
     cy.get('[data-testid="contact-phone"]').should("have.text", "Phone: ");
     cy.get('[data-testid="phone-num"]').should("have.text", "123-555-6789");
   });

--- a/cypress/e2e/jobsApplicationSpec.cy.js
+++ b/cypress/e2e/jobsApplicationSpec.cy.js
@@ -515,6 +515,7 @@ describe("Editability of specific job application fields", () => {
     cy.get('[data-testid="job-status"]').should("have.text", "Offer")
     cy.get('[data-testid="job-notes"]').should('contain', 'Talked with recruiter, sounds like a great opportunity to learn new things')
     cy.get('[data-testid="job-URL"]').should('contain', 'https://example.com')
+    cy.get('[data-testid="job-URL"]').should('have.attr', 'href').and('include', 'https://example.com')
     cy.get('[data-testid="job-description"]').should('contain', 'Frontend Developer of React only with no CSS')
   });
 
@@ -539,6 +540,7 @@ describe("Editability of specific job application fields", () => {
     cy.get('[data-testid="job-status"]').should("have.text", "Interviewing")
     cy.get('[data-testid="job-notes"]').should('contain', 'Had a technical interview, awaiting decision.')
     cy.get('[data-testid="job-URL"]').should('contain', 'https://creativesolutions.com/careers/backend-developer')
+    cy.get('[data-testid="job-URL"]').should('have.attr', 'href').and('include', 'https://creativesolutions.com/careers/backend-developer')
     cy.get('[data-testid="job-description"]').should('contain', 'Developing RESTful APIs and optimizing server performance.')
   });
 });

--- a/src/components/contacts/ShowContact.tsx
+++ b/src/components/contacts/ShowContact.tsx
@@ -149,7 +149,9 @@ function ShowContact() {
                 >
                   Email:{" "}
                 </span>
-                <a data-testid="email-address" href={`mailto:${contact.attributes.email}`} >{contact.attributes.email}</a>
+                <a 
+                  className="text-cyan-500 underline hover:text-cyan-700"
+                  data-testid="email-address" href={`mailto:${contact.attributes.email}`} >{contact.attributes.email}</a>
               </p>
               <p>
                 <span
@@ -184,7 +186,7 @@ function ShowContact() {
             <ul className="list-disc list-inside">
               {filteredOtherContacts.map((otherContact) => (
                 <li key={otherContact.id} className="font-normal">
-                  <Link to={`/contacts/${otherContact.id}`}>
+                  <Link className="text-cyan-500 underline hover:text-cyan-700" to={`/contacts/${otherContact.id}`}>
                     <td className="p-4 border-b truncate max-w-[8vw]">
                     {otherContact.attributes.first_name}{" "}
                     {otherContact.attributes.last_name}

--- a/src/components/contacts/ShowContact.tsx
+++ b/src/components/contacts/ShowContact.tsx
@@ -149,11 +149,7 @@ function ShowContact() {
                 >
                   Email:{" "}
                 </span>
-                <span data-testid="email-address">
-                  {/* href mailto: */}
-                  {/* {contact.attributes.email} */}
-                  <a href={`mailto:${contact.attributes.email}`} >{contact.attributes.email}</a>
-                </span>
+                <a data-testid="email-address" href={`mailto:${contact.attributes.email}`} >{contact.attributes.email}</a>
               </p>
               <p>
                 <span

--- a/src/components/contacts/ShowContact.tsx
+++ b/src/components/contacts/ShowContact.tsx
@@ -150,7 +150,9 @@ function ShowContact() {
                   Email:{" "}
                 </span>
                 <span data-testid="email-address">
-                  {contact.attributes.email}
+                  {/* href mailto: */}
+                  {/* {contact.attributes.email} */}
+                  <a href={`mailto:${contact.attributes.email}`} >{contact.attributes.email}</a>
                 </span>
               </p>
               <p>


### PR DESCRIPTION
## Type of Change
- [x] feature ⛲
- [x] documentation update 📃
- [x] styling 🎨
- [x] testing 🧪
<!--- Delete any above that do not apply to this PR -->

## Description
This feature changes the email field on ShowContact to be a link that opens the user's client email. It also cleans up some small issues in the readme and adds some more robust testing around existing link's in the app.

## Motivation and Context
Users can now more easily email their contacts.

## Related Tickets
Closes https://github.com/orgs/turingschool/projects/15/views/1?pane=issue&itemId=96675804&issue=turingschool%7Ctracker-crm%7C89

## Screenshots (if appropriate):

![Screenshot 2025-02-07 at 1 28 37 PM](https://github.com/user-attachments/assets/91cc1523-da6c-4e6e-a35a-9bcd7846bb19)


## Added Test?
- [x] Yes 🫡
  - <!--- If yes, what type? Integration(FE), Unit/Model or Request/Controller Specs?-->
- [x] All previous tests still pass 🥳
<!--- Delete any above that do not apply to this PR -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.