### PR TITLE
Refactor/delete interface

### DIFF
--- a/src/Interfaces.tsx
+++ b/src/Interfaces.tsx
@@ -168,3 +168,17 @@ export interface DashBoardDattaI{
     sectionUrl: string;
     sectionDescription: string
 }
+
+  export interface DeleteItemProps {
+    userId: number;
+    itemId: string | number;
+    itemType: string;
+    deleteAction: (
+      userId: number,
+      itemType: string,
+      itemId: string | number,
+      token: string
+    ) => Promise<boolean>;
+    token: string;
+    onDeleteSuccess: () => void;
+}

--- a/src/components/common/DeleteItem.tsx
+++ b/src/components/common/DeleteItem.tsx
@@ -1,18 +1,6 @@
 import { useState } from "react";
+import { DeleteItemProps } from "../../Interfaces";
 
-interface DeleteItemProps {
-  userId: number;
-  itemId: string | number;
-  itemType: string;
-  deleteAction: (
-    userId: number,
-    itemType: string,
-    itemId: string | number,
-    token: string
-  ) => Promise<boolean>;
-  token: string;
-  onDeleteSuccess: () => void;
-}
 
 const DeleteItem = ({
   userId,


### PR DESCRIPTION
## Type of Change
- [ x ] refactor 🧑‍💻

## Description
This PR moves the DeleteItemProps interface from the DeleteItem.tsx file to the Interfaces.tsx file and updates DeleteItem.tsx to import the interface.

## Motivation and Context
Keeps consistancy by having all interfaces centralized in one location.

## Related Tickets
closes #117 https://github.com/turingschool/tracker-crm-fe/issues/117

## Screenshots (if appropriate):

## Added Test?

- [ x ] No 🙅
- [ x ] All previous tests still pass 🥳


## Checklist:

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.