### PR TITLE
fix/add asterisk to application url

### DIFF
--- a/src/components/JobApplications/NewJobApplication.tsx
+++ b/src/components/JobApplications/NewJobApplication.tsx
@@ -246,18 +246,16 @@ const filteredContacts = contacts.filter(contact => {
                 ))}
               </select>
             </label>
+            <div className="text-red-500">
+              <p className='m-2'>* Required Fields</p>
+            </div>
           </div>
-<div className="font-semibold">
-<p className='m-2'>* Required Fields</p>
 
-</div>
-
-          
           <div className='m-2'>
 
             {/* Application URL */}
             <label className="text-[1vw] font-[Helvetica Neue] flex flex-col">
-              <span className="font-semibold">Application URL:</span>
+              <span className="font-semibold">Application URL:<span className="text-red-500"> *</span></span>
               <input
                 type="url"
                 id="appURL"


### PR DESCRIPTION
## Type of Change
- [x] feature ⛲
- [x] styling 🎨
- [x] refactor 🧑‍💻
<!--- Delete any above that do not apply to this PR -->

## Description
<!--- Describe your changes in detail -->
This PR adds a red asterisk to identify application URL as a required field when a user completes a new job application. It also moves the "Required Fields" flag to intended location. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to closed issue 125 - fixes issue missed initially. 

## Related Tickets
<!--- example: closes #12 https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Screenshots (if appropriate):

## Added Test?
- [x] No 
- [x] All previous tests still pass 🥳
<!--- Delete any above that do not apply to this PR -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.