### PR TITLE
fix/bug in adding a new company from new contact page

### DIFF
--- a/cypress/e2e/newContactSpec.cy.js
+++ b/cypress/e2e/newContactSpec.cy.js
@@ -380,7 +380,7 @@ describe("New Contacts page after logging in", () => {
       cy.get("#lastName").type("Boots");
       cy.contains("Add New Contact");
       cy.contains("button", "Add new company").click();
-      cy.wait(5000)
+      cy.wait(5000) //including a wait period in this test due to a bug that was causing the modal to close unexpectedly after opening 
 
       cy.get("label").contains("Company Name:").should("exist");
       cy.get("label").contains("Website:").should("exist");

--- a/cypress/e2e/newContactSpec.cy.js
+++ b/cypress/e2e/newContactSpec.cy.js
@@ -376,6 +376,8 @@ describe("New Contacts page after logging in", () => {
 
     it("Should keep the add company modal open when clicked", () => {
       cy.get("a > .bg-cyan-600").click();
+      cy.get("#firstName").type("Emma");
+      cy.get("#lastName").type("Boots");
       cy.contains("Add New Contact");
       cy.contains("button", "Add new company").click();
       cy.wait(5000)

--- a/cypress/e2e/newContactSpec.cy.js
+++ b/cypress/e2e/newContactSpec.cy.js
@@ -211,6 +211,9 @@ describe("New Contacts page after logging in", () => {
       }).as("getUpdatedCompanies");
 
       cy.get("a > .bg-cyan-600").click();
+      cy.get("#firstName").type("Emma");
+      cy.get("#lastName").type("Boots");
+
       cy.contains("button", "Add new company").click();
       cy.get("label").contains("Company Name:").should("exist");
       cy.get("label").contains("Website:").should("exist");
@@ -236,9 +239,6 @@ describe("New Contacts page after logging in", () => {
         .should("have.value", "3")
         .find("option:selected")
         .should("have.text", "Company C");
-
-      cy.get("#firstName").type("Emma");
-      cy.get("#lastName").type("Boots");
 
       cy.get('button[type="submit"]').click();
 
@@ -373,5 +373,20 @@ describe("New Contacts page after logging in", () => {
       );
       cy.contains("button", "X").scrollIntoView().click();
     });
+
+    it("Should keep the add company modal open when clicked", () => {
+      cy.get("a > .bg-cyan-600").click();
+      cy.contains("Add New Contact");
+      cy.contains("button", "Add new company").click();
+      cy.wait(5000)
+
+      cy.get("label").contains("Company Name:").should("exist");
+      cy.get("label").contains("Website:").should("exist");
+      cy.get("label").contains("Street Address:").should("exist");
+      cy.get("label").contains("City:").should("exist");
+      cy.get("label").contains("State:").should("exist");
+      cy.get("label").contains("Zip Code:").should("exist");
+      cy.get("label").contains("Notes:").should("exist");
+    })
   });
 });

--- a/src/components/contacts/NewContact.tsx
+++ b/src/components/contacts/NewContact.tsx
@@ -241,6 +241,7 @@ const NewContact = ({ userData }: UserInformationProps) => {
             </select>
             <div>
               <button
+                type="button"
                 className="bg-cyan-600 text-white px-[.5vw] py-[1vh] rounded w-[18vw] hover:bg-cyan-700 focus:ring-cyan-500 focus:ring-2 mt-3"
                 onClick={() => setIsOpen(true)}
               >


### PR DESCRIPTION
## Type of Change
- [x] bug fix 🐛
- [x] testing 🧪
<!--- Delete any above that do not apply to this PR -->

## Description
<!--- Describe your changes in detail -->
This PR adds the type "button" to the button on the new contact form to add a new company to fix the bug that was causing the new company modal to close before a new company could be added. It also refactors an existing Cypress test and adds an additional sad path test. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Because the button to add a new company from the new contact page was not assigned a type, it was defaulting to a submit button. This caused the form to submit when the add new company button was clicked, which resulted in the new company modal temporarily opening but then closing. Adding type "button" to the add new company button prevents the form from immediately submitting when clicked. 

## Related Tickets
<!--- example: closes #12 https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
Closes Issue #145 
## Screenshots (if appropriate):

## Added Test?
- [x] Yes 🫡
  - <!--- If yes, what type? Integration(FE), Unit/Model or Request/Controller Specs?-->
  - Refactored existing test and added a sad path test to verify that the modal is not closing prematurely. 
- [x] All previous tests still pass 🥳
<!--- Delete any above that do not apply to this PR -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.