### PR TITLE
Refactor: company modal data persisting.

### DIFF
--- a/cypress/e2e/companyShowSpec.cy.js
+++ b/cypress/e2e/companyShowSpec.cy.js
@@ -246,5 +246,33 @@ describe("Company Show Page", () => {
 
     cy.get('[data-cytest="modal"]').should("not.exist");
   });
+
+  it("Should have persisting data after closing/reopening the modal", () => {
+    cy.get('[data-cytest="edit-button"]').click();
+    
+    cy.get('[data-cytest="name-input"]').clear().type("Updated Company");
+    cy.get('[data-cytest="website-input"]').clear().type("https://updated.com");
+    
+    cy.get('[data-cytest="close-button"]').click();
+    cy.get('[data-cytest="modal"]').should("not.exist");
+    
+    cy.get('[data-cytest="edit-button"]').click();
+    
+    cy.get('[data-cytest="name-input"]').should("have.value", "Updated Company");
+    cy.get('[data-cytest="website-input"]').should("have.value", "https://updated.com");
+  });
+
+  it("Should allow only numbers in the ZIP code field and format correctly", () => {
+    cy.get('[data-cytest="edit-button"]').click();
+  
+    cy.get('[data-cytest="zip-code-input"]').clear().type("1234abc5678");
+    cy.get('[data-cytest="zip-code-input"]').should("have.value", "12345-678");
+  
+    cy.get('[data-cytest="zip-code-input"]').clear().type("98765");
+    cy.get('[data-cytest="zip-code-input"]').should("have.value", "98765");
+  
+    cy.get('[data-cytest="zip-code-input"]').clear().type("987654321");
+    cy.get('[data-cytest="zip-code-input"]').should("have.value", "98765-4321");
+  });  
 });
 

--- a/src/components/companies/CompanyShow.tsx
+++ b/src/components/companies/CompanyShow.tsx
@@ -56,7 +56,6 @@ function CompanyShow() {
     notes: ""
   });
 
-  
   useEffect(() => {
     console.log("Fetching company data...");
     setIsLoading(true);
@@ -91,20 +90,20 @@ function CompanyShow() {
     fetchCompanyData();
   }, [token, userData, id]);
 
-useEffect(() => {
-  if (companyData) {
-    const attributes = companyData.company.data.attributes;
-    setFormData({
-      name: attributes.name || "",
-      website: attributes.website || "",
-      streetAddress: attributes.street_address || "",
-      city: attributes.city || "",
-      selectedState: attributes.state || "",
-      zipCode: attributes.zip_code || "",
-      notes: attributes.notes || ""
-    });
-  }
-}, [companyData]);
+  useEffect(() => {
+    if (companyData) {
+      const attributes = companyData.company.data.attributes;
+      setFormData({
+        name: attributes.name || "",
+        website: attributes.website || "",
+        streetAddress: attributes.street_address || "",
+        city: attributes.city || "",
+        selectedState: attributes.state || "",
+        zipCode: attributes.zip_code || "",
+        notes: attributes.notes || ""
+      });
+    }
+  }, [companyData]);
 
   const handleEditClick = () => {
     setIsEditModalOpen(true);


### PR DESCRIPTION
## Type of Change
- [x] refactor 🧑‍💻
- [x] testing 🧪
<!--- Delete any above that do not apply to this PR -->

## Description
Refactored the CompanyShow.tsx file to have user typed data persist upon accidental closing of the modal.

The zip code input field also was allowing letters and characters to be saved. I made it where only integers are accepted. The 5 digit and 9 digit zip-codes are allowed and the field will automatically insert a hyphen if typing more that 5 digits.

Cypress tests have been added to verify the data persists and to verify the zip-code.
<!--- Describe your changes in detail -->

## Motivation and Context
The company edit modal was not saving data that the user typed in any of the fields if that user closed the modal on accident.

Now the data will persist until the user clicks save or navigates to another page that is not the Company Details page.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Related Tickets
closes [#141](https://github.com/turingschool/tracker-crm/issues/141)
<!--- example: closes #12 https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Screenshots (if appropriate):

## Added Test?
- [x] Yes 🫡
  - <!--- If yes, what type? Integration(FE), Unit/Model or Request/Controller Specs?-->
- [x] All previous tests still pass 🥳
<!--- Delete any above that do not apply to this PR -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.