### PR TITLE
Turing logo visibility

### DIFF
--- a/cypress/e2e/menuBarSpec.cy.js
+++ b/cypress/e2e/menuBarSpec.cy.js
@@ -220,6 +220,17 @@ it(" if plus icon is clicked multiple times, still behaves correctly", () => {
       cy.get('[data-testid="menu-iconM"]').click().click();
       cy.get('[data-testid="slideout-menu"]').should("not.be.visible");
     });
+
+    it("should display the Turing logo in the top of the menu bar", () => {
+      cy.get('[data-testid="close-iconM"]').click();
+      cy.get('.w-11').should("be.visible");
+    });
+
+    it("Turing logo when clicked will navigative to home screen", () => {
+      cy.get('[data-testid="close-iconM"]').click();
+      cy.get('.w-11').should("be.visible").click();
+      cy.url().should("include", "/home");
+    });
   });
 
   it("Should have a quad-color-bar to the right of the nav bar", () => {

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -119,21 +119,26 @@ function MenuBar() {
       </nav>
 
       {/* -- MOBILE HAMBURGER, shown on small screens only -- */}
-      <button className="flex items-center justify-items-center visible sm:hidden p-2" onClick={toggleSideMenu}>
-        <MenuIcon data-testid="menu-iconM" fontSize="large" className="m-auto justify-items-center"/>
-      </button>
-
+      <div className="relative h-screen">
+        {/* Logo */}
+          <Link className="absolute top-2 left-1 sm:hidden z-5" to="/" onClick={toggleSideMenu}>
+            <img className="w-11" src={logo} alt="Logo" />
+          </Link>
+        <button className="flex items-center h-full visible sm:hidden p-2" onClick={toggleSideMenu}>
+          <MenuIcon data-testid="menu-iconM" fontSize="large" className="m-auto justify-items-center"/>
+        </button>
+      </div>
+        
       {/* -- MOBILE SLIDE-OUT MENU, shown on small screens only -- */}
       <nav className={"fixed flex flex-col top-0 left-0 z-10 bg-[#046576] w-64 h-screen transition-all duration-500 " +
         (sideMenuOpen ? "-translate-x-full" : "translate-x-0")} data-testid="slideout-menu">
         <button className="min-sm:hidden m-4 text-white" onClick={toggleSideMenu}>
           <CloseIcon fontSize="large" data-testid="close-iconM" className="m-auto text-white"/>
         </button>
-
-        {/* Logo */}
-        <Link className="block text-center my-4" to="/" onClick={toggleSideMenu}>
-          <img className="mx-auto w-1/2" src={logo} alt="Logo" />
-        </Link>
+         {/* Logo */}
+         <Link className="block text-center my-4" to="/" onClick={toggleSideMenu}>
+            <img className="mx-auto w-1/2" src={logo} alt="Logo" />
+          </Link>
         {/* Home */}
         <NavLink className="m-auto mt-[1vh] text-white" to="/home" data-testid="home-iconM" onClick={toggleSideMenu}>
           <HomeIcon fontSize="large" />


### PR DESCRIPTION
### Type of Change
- [ ] styling 🎨
- [ ] testing 🧪
<!--- Delete any above that do not apply to this PR -->

### Description
<!--- Describe your changes in detail -->

- Added Turing Logo to menu bar so it is visible when the menu bar is closed
- Styled using tailwind 
- Test has been added to ensure Turing logo is visible 
- Test has been added to ensure the user will be brought to the home page when the logo is clicked

### Share the reason(s) for this pull request
<!--- Why is this change required? What problem does it solve? -->
This change enhances the User experience by adding styling 
while also allowing the user to navigate to the home page by clicking the logo. 

### What questions do you have/what do you want feedback on?
<!--- List any specific questions and feedback requests -->
- Does the logo size look good, or should it be different?
- Would you have done anything different?

### Screenshots (if applicable):

![Screenshot 2025-03-26 at 2 27 14 PM](https://github.com/user-attachments/assets/c568ab2d-d2e8-4c0f-a855-ba5e31220fab)

### Added Test?
- [ ] Yes 🫡
Integration(menuBarSpec.cy.js)

### Checklist:
- [ ] My code follows the code style of this project.
- [ ] All tests (previous and new) pass 🥳

### How to QA this change:
<!--- Outline the steps needed to locally verify the implemented changes are working as intended -->
1. Log in
2. When in mobile view you will see a Turing logo in the top of the unopened menu bar on the left side.
