### PR TITLE
Styling login userreg forms

### DIFF
--- a/cypress/e2e/loginSpec.cy.js
+++ b/cypress/e2e/loginSpec.cy.js
@@ -23,7 +23,8 @@ describe('testing for Login page', () => {
     .get('.login-form-wrap > .form-inputs > form > .login-btn').should('contain', 'Login')
   
     .get('.no-account-message').should('be.visible')
-    .get('.no-account-message').should('contain', 'No Account? Click Here To Register.')
+    .get('.no-account-message').should('contain', 'No Account?')
+		.get('.register-message').should('contain', 'Click Here To Register.')
 
     .get('a').should('be.visible')
     .get('a').should('contain', 'Here')

--- a/cypress/e2e/userRegistrationSpec.cy.js
+++ b/cypress/e2e/userRegistrationSpec.cy.js
@@ -26,8 +26,8 @@ describe('User Registration Form - Create New User', () => {
     cy.get('label').eq(1).should('contain', 'Email');
     cy.get('label').eq(2).should('contain', 'Password');
     cy.get('label').eq(3).should('contain', 'Confirm Password');
-    cy.get('p.login-link').should('contain', 'Already have an account?');
-    cy.get('a.link-to-login').should('contain', 'Click here to login.');
+    cy.get('.account-message').should('contain', 'Already have an account?');
+    cy.get('.link-to-login').should('contain', 'Click Here to login.');
     cy.get('.tracker').should('contain', 'Tracker');
     cy.get('.by-turing').should('contain', 'by Turing');
     cy.get('.app-tagline').should('contain', 'Job hunting made easier');

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -92,7 +92,7 @@ const LoginForm: React.FC = () => {
               Login
           </button>
           <p className='no-account-message font-[Helvetica Neue] font-sans'>No Account?</p>
-					<p className='no-account-message font-[Helvetica Neue] font-sans'> Click <NavLink to="/UserRegistration" className="text-purple-500 hover:underline">Here</NavLink> To Register.</p>
+					<p className='register-message font-[Helvetica Neue] font-sans'> Click <NavLink to="/UserRegistration" className="text-purple-500 hover:underline">Here</NavLink> To Register.</p>
 
         </form>
         {errorMessage && <p className='failed-login flex justify-center items-center rounded-md border-red-600 border-2 bg-slate-700 w-[50%] h-[5%] absolute top-[25%] left-[25%] font-[Helvetica Neue] font-sans font-semibold text-lg text-red-600'>{errorMessage}</p>}

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -59,7 +59,7 @@ const LoginForm: React.FC = () => {
         <form onSubmit={handleSubmit} className='flex flex-col justify-evenly items-center md:w-[24vw] mx-[6vw] md:mx-[12vw] my-[30vh]'>
         <img className='turing-logo -mt-[24vh] -ml-[30vw] mb-[24vh] size-20' src={turingLogo} />
 
-          <h1 className='font-[Helvetica Neue] font-sans  text-xl'>
+          <h1 className='font-[Helvetica Neue] font-sans text-xl'>
             Please login
           </h1>
           <div className='email-input flex flex-col justify-center w-[100%] mb-[10px]'>
@@ -87,7 +87,7 @@ const LoginForm: React.FC = () => {
           <button 
             type="submit" 
             id="submit" 
-            className='login-btn w-[35%] min-h-10vh h-[10%] rounded-sm bg-[#3cb6cc] font-[Helvetica Neue] font-sans text-base'
+            className='login-btn flex justify-center items-center bg-cyan-800 text-white rounded h-12 w-40 p-[8px] mt-[4px] hover:bg-cyan-600 focus:ring-2 focus:ring-cyan-500'
             data-testid="login-button">
               Login
           </button>

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -87,11 +87,12 @@ const LoginForm: React.FC = () => {
           <button 
             type="submit" 
             id="submit" 
-            className='login-btn flex justify-center items-center bg-cyan-800 text-white rounded h-12 w-40 p-[8px] mt-[4px] hover:bg-cyan-600 focus:ring-2 focus:ring-cyan-500'
+            className='login-btn flex justify-center items-center bg-cyan-800 text-white rounded h-12 w-40 p-[8px] mt-[4px] mb-[4px] hover:bg-cyan-600 focus:ring-2 focus:ring-cyan-500'
             data-testid="login-button">
               Login
           </button>
-          <p className='no-account-message font-[Helvetica Neue] font-sans'>No Account? Click <NavLink to="/UserRegistration" className="text-purple-500 underline">Here</NavLink> To Register.</p>
+          <p className='no-account-message font-[Helvetica Neue] font-sans'>No Account?</p>
+					<p className='no-account-message font-[Helvetica Neue] font-sans'> Click <NavLink to="/UserRegistration" className="text-purple-500 hover:underline">Here</NavLink> To Register.</p>
 
         </form>
         {errorMessage && <p className='failed-login flex justify-center items-center rounded-md border-red-600 border-2 bg-slate-700 w-[50%] h-[5%] absolute top-[25%] left-[25%] font-[Helvetica Neue] font-sans font-semibold text-lg text-red-600'>{errorMessage}</p>}

--- a/src/components/UserRegistration.tsx
+++ b/src/components/UserRegistration.tsx
@@ -130,7 +130,7 @@ function UserRegistration(): React.ReactElement {
                   Already have an account?
 								</p>
 								<p>
-                  Click <NavLink to="/" className="link-to-login text-purple-500 hover:underline">here</NavLink> to login.
+                  Click <NavLink to="/" className="link-to-login text-purple-500 hover:underline">Here</NavLink> to login.
                 </p>
               </div>
             </form>

--- a/src/components/UserRegistration.tsx
+++ b/src/components/UserRegistration.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import turingLogo from '../Turing-logo.png';
 import FormField from './layout/FormField';
-import { Link, useNavigate } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 import ClipLoader from 'react-spinners/ClipLoader'; // Import the spinner
 import { registerUser } from '../apiCalls';
 import { loginUser } from '../trackerApiCalls';
@@ -81,15 +81,15 @@ function UserRegistration(): React.ReactElement {
         </div>
       ) : (
         <>
-          <div className="form-inputs w-6/12 flex flex-col items-center">
-            <img className="turing-logo absolute top-5 left-5 size-20" src={turingLogo} alt="Turing Logo" />
+          <div className="form-inputs w-6/12 flex flex-col">
+            <form onSubmit={handleFormSubmit} className='flex flex-col justify-evenly items-center md:w-[24vw] mx-[6vw] md:mx-[12vw] my-[20vh]'>
+						<img className="turing-logo -mt-[14vh] -ml-[30vw] mb-[14vh] size-20" src={turingLogo} alt="Turing Logo" />
 
-            <form onSubmit={handleFormSubmit}>
-              <h1 className="create-account text-4xl text-gray-600 font-[Helvetica Neue] text-center mt-40 mb-10 tracking-wider">
+              <h1 className="create-account font-[Helvetica Neue] font-sans text-xl">
                 Create Account
               </h1>
 
-              <div>
+              <div className="flex flex-col justify-center w-[100%] mb-[2px]">
                 <FormField
                   formType="text"
                   state={name}
@@ -118,21 +118,19 @@ function UserRegistration(): React.ReactElement {
 
               {errorMessage && <p className="error-message">{errorMessage}</p>}
 
-              <div className="mt-5 flex flex-col items-center justify-center">
+              <div className=" flex flex-col items-center justify-center">
                 <button
                   type="submit"
-                  className="flex justify-center items-center bg-cyan-800 text-white rounded h-12 w-40 p-[8px] mt-[4px] hover:bg-cyan-600 focus:ring-2 focus:ring-cyan-500"
+                  className="flex justify-center items-center bg-cyan-800 text-white rounded h-12 w-40 p-[8px] mt-[4px] mb-[4px] hover:bg-cyan-600 focus:ring-2 focus:ring-cyan-500"
                   data-cy="register-button"
                 >
                   Register
                 </button>
-                <p className="login-link text-gray-500 text-xl font-extralight block mt-4 text-center">
+                <p className="login-link font-[Helvetica Neue] font-sans">
                   Already have an account?
-                  <br />
-                  <Link to="/" className="link-to-login hover:underline">
-                  {/* Is this the correct endpoint for the login page? */}
-                    Click here to login.
-                  </Link>
+								</p>
+								<p>
+                  Click <NavLink to="/" className="link-to-login text-purple-500 hover:underline">here</NavLink> to login.
                 </p>
               </div>
             </form>

--- a/src/components/UserRegistration.tsx
+++ b/src/components/UserRegistration.tsx
@@ -126,10 +126,10 @@ function UserRegistration(): React.ReactElement {
                 >
                   Register
                 </button>
-                <p className="login-link font-[Helvetica Neue] font-sans">
+                <p className="account-message font-[Helvetica Neue] font-sans">
                   Already have an account?
 								</p>
-								<p>
+								<p className="link-to-login">
                   Click <NavLink to="/" className="link-to-login text-purple-500 hover:underline">Here</NavLink> to login.
                 </p>
               </div>

--- a/src/components/UserRegistration.tsx
+++ b/src/components/UserRegistration.tsx
@@ -85,9 +85,9 @@ function UserRegistration(): React.ReactElement {
             <img className="turing-logo absolute top-5 left-5 size-20" src={turingLogo} alt="Turing Logo" />
 
             <form onSubmit={handleFormSubmit}>
-              <h2 className="create-account text-4xl text-gray-600 font-[Helvetica Neue] text-center mt-40 mb-10 tracking-wider">
+              <h1 className="create-account text-4xl text-gray-600 font-[Helvetica Neue] text-center mt-40 mb-10 tracking-wider">
                 Create Account
-              </h2>
+              </h1>
 
               <div>
                 <FormField


### PR DESCRIPTION
### Type of Change
- [x] styling 🎨
- [x] refactor 🧑‍💻
- [x] testing 🧪

### Description
- Correct Turing Logo alignment to match on both Login and User Registration Components.
- Adjust "Create Account" Header to match "Please Login" Header.
- Adjust "Login" Button to match "Register" Button styling.
- Update "Already have an account?" text so that it matches the styling of "No Account?" text
- Update "Here" stying to be purple with an underline hover effect to indicate a link.

### Share the reason(s) for this pull request
To make the login and user registration forms look more uniform.

### What questions do you have/what do you want feedback on?
I just wanted to make sure I didn't miss any styling differences.

### Screenshots (if applicable):
![Screenshot 2025-03-27 at 3 41 48 PM](https://github.com/user-attachments/assets/2b2eca7e-0316-474b-b924-41969193c1b6)

![Screenshot 2025-03-27 at 3 41 57 PM](https://github.com/user-attachments/assets/35de4fad-a686-40d1-b076-eaf2a589d45c)

### Added Test?
- [ ] Yes 🫡
- [ ] No 🙅
- [x] Updated - Updated Cypress Testing on LoginSpec and UserRegistration Spec to match new class names


### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] All tests (previous and new) pass 🥳

### How to QA this change:
start the front end locally with `npm start`
switch between the login and user registration pages by click the "Here" link on both.

