### PR TITLE
Entire job application bar/section clickable to take to direct to applications

### DIFF
--- a/src/components/JobApplications/JobApplications.tsx
+++ b/src/components/JobApplications/JobApplications.tsx
@@ -79,18 +79,21 @@ const ApplicationsGrid: React.FC = () => {
                     key={app.id}
                     className="text-gray-600 hover:bg-gray-100 cursor-pointer"
                   >
-                    <td className="p-4 border-b">
-                      <Link to={`/job_applications/${app.id}`}>
+                    <td className="p-2 border-b">
+                      <Link to={`/job_applications/${app.id}`}
+                      className="block w-full h-full p-2">
                         {app.company_name || app.company_id}
                       </Link>
                     </td>
-                    <td className="p-4 border-b">
-                      <Link to={`/job_applications/${app.id}`}>
+                    <td className="p-2 border-b">
+                      <Link to={`/job_applications/${app.id}`}
+                      className="block w-full h-full p-2">
                         {app.position_title}
                       </Link>
                     </td>
-                    <td className="p-4 border-b">
-                      <Link to={`/job_applications/${app.id}`}>
+                    <td className="p-2 border-b">
+                      <Link to={`/job_applications/${app.id}`}
+                      className="block w-full h-full p-2">
                         <span
                           className={`py-2 px-6 text-sm inline-block text-center w-[10vw] min-w-[80px] max-w-[200px] 
               truncate overflow-hidden whitespace-nowrap ${statusStyles[statusMap[app.status]]}`}
@@ -99,8 +102,9 @@ const ApplicationsGrid: React.FC = () => {
                         </span>
                       </Link>
                     </td>
-                    <td className="p-4 border-b">
-                      <Link to={`/job_applications/${app.id}`}>
+                    <td className="p-2 border-b">
+                      <Link to={`/job_applications/${app.id}`}
+                      className="block w-full h-full p-2">
                         {app.updated_at}
                       </Link>
                     </td>


### PR DESCRIPTION
### Type of Change
- [x] feature ⛲
- [x] styling 🎨

### Description
In this pull request, the functionality to be able to click the entire application bar (vs. previous, only could click on names of section). Minor styling change implemented in padding to keep styling cohesive. 

### Share the reason(s) for this pull request
This change was done to make it more efficient/easier to direct to the page of a given application. 

### What questions do you have/what do you want feedback on?
I don't know that I have any questions at this time in regards to this task. I do feel it was pretty straightforward, any blockers I did have were unrelated to the code itself. 

### Related Tickets
closes #155  [https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->](https://github.com/orgs/turingschool/projects/15/views/1?pane=issue&itemId=99759480&issue=turingschool%7Ctracker-crm%7C155)

### Screenshots (if appllicable):

### Added Test?
- [ ] Yes 🫡
- [x] No 🙅



### Checklist:
- [x] My code follows the code style of this project.
- [x] All tests (previous and new) pass 🥳


### How to QA this change:
Log in on local, direct to applications page. Section that holds applications on this page should be entirely clickable and should direct a user to that specified application's page. 

