### PR TITLE
Refactor dashboard "Add New" button visibility 

### DIFF
--- a/cypress/e2e/dashBoardSpec.cy.js
+++ b/cypress/e2e/dashBoardSpec.cy.js
@@ -198,20 +198,35 @@ describe('Dash Board buttons to add new resources', () => {
     cy.get('[data-cy="companyBtn"]').should("exist").and("have.text", "Add new company");
   });
 
-  it("should keep all 'Add new' buttons visible when one resource has data", () => {
-    cy.intercept("GET", "**/api/v1/users/1/dashboard", {
-      jobApplications: [{ id: 1, title: "Software Engineer" }],
-      contacts: [],
-      companies: [],
-    }).as("getDashboardData");
-  
-    cy.reload();
-    cy.wait("@getDashboardData");
-  
-    cy.get('[data-cy="jobBtn"]').should("exist").and("have.text", "Add new Job");
-    cy.get('[data-cy="contactBtn"]').should("exist").and("have.text", "Add new Contact");
-    cy.get('[data-cy="companyBtn"]').should("exist").and("have.text", "Add new Company");
-  });
+  it("should render all 'Add new' buttons when one resource has data", () => {
+    cy.fixture("mockDashBoardSingleJobData").then((data) => {
+      data.jobApplications = [
+        {
+          id: 1,
+          position_title: "Jr. CTO",
+          date_applied: "2024-10-31",
+          status: 1,
+          notes: "Fingers crossed!",
+          job_description: "Looking for Turing grad/jr dev to be CTO",
+          application_url: "www.example.com",
+          created_at: "2024-12-16T21:16:09.601Z",
+          updated_at: "2024-12-16T21:16:09.601Z",
+          company_id: 1,
+          user_id: 1
+        }
+      ]
+      cy.intercept("GET", "**/api/v1/users/1/dashboard", {
+        statusCode: 200,
+        body: data,
+      }).as("getDashboardData");
+      cy.reload()
+      cy.wait("@getDashboardData")
+
+      cy.get('[data-cy="jobApplicationBtn"]').should("exist").and("have.text", "Add new job application");
+      cy.get('[data-cy="contactBtn"]').should("exist").and("have.text", "Add new contact");
+      cy.get('[data-cy="companyBtn"]').should("exist").and("have.text", "Add new company");
+    })
+  })
 
   it("should not render any buttons when all sections have data", () => {
     cy.fixture("mockDashBoardNoJobsContactsOrCompanies").then((data) => {

--- a/cypress/e2e/dashBoardSpec.cy.js
+++ b/cypress/e2e/dashBoardSpec.cy.js
@@ -119,53 +119,49 @@ describe('Dash Board after loggging in with zero recent jobs, contacts and compa
   });
 })
 
-  describe('Dash Board buttons to add new resources', () => {
-    beforeEach(()=>{
-      cy.intercept("POST", "http://localhost:3001/api/v1/sessions", {
-        statusCode: 200,
-        body: {
-          token: 'fake-token',
-          user: {
-            data: {
-              id: 1,
-              type: 'user',
-              attributes: {
-                name: 'Danny DeVito',
-                email: 'danny_de@email.com',
-                companies: []
-              }
+describe('Dash Board buttons to add new resources', () => {
+  beforeEach(()=>{
+    cy.intercept("POST", "http://localhost:3001/api/v1/sessions", {
+      statusCode: 200,
+      body: {
+        token: 'fake-token',
+        user: {
+          data: {
+            id: 1,
+            type: 'user',
+            attributes: {
+              name: 'Danny DeVito',
+              email: 'danny_de@email.com',
+              companies: []
             }
           }
         }
-      }).as("mockSession2");
-  
-      cy.intercept(
-        'GET',
-        'http://localhost:3001/api/v1/users/1/dashboard',
-        { statusCode: 200, fixture: 'mockDashBoardNoJobsContactsOrCompanies' }
-      );
+      }
+    }).as("mockSession2");
 
-      cy.intercept("GET", "http://localhost:3001/api/v1/users/1/contacts", {
-        statusCode: 200,
-        body: mockContactsData,
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }).as("getContacts");
+    cy.intercept(
+      'GET',
+      'http://localhost:3001/api/v1/users/1/dashboard',
+      { statusCode: 200, fixture: 'mockDashBoardNoJobsContactsOrCompanies' }
+    ).as("getDashboardData");
 
-      cy.intercept("GET", `http://localhost:3001/api/v1/users/1/companies`, {
-        statusCode: 200,
-        body: mockCompanies,
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }).as("getCompanies");
-  
-      cy.visit("http://localhost:3000/");
-      cy.get("#email").type("danny_de@email.com")
-      cy.get("#password").type("jerseyMikesRox7")
-      cy.get('[data-testid="login-button"]').click();
-    })
+    cy.intercept("GET", "http://localhost:3001/api/v1/users/1/contacts", {
+      statusCode: 200,
+      body: mockContactsData,
+      headers: { "Content-Type": "application/json" },
+    }).as("getContacts");
+
+    cy.intercept("GET", `http://localhost:3001/api/v1/users/1/companies`, {
+      statusCode: 200,
+      body: mockCompanies,
+      headers: { "Content-Type": "application/json" },
+    }).as("getCompanies");
+
+    cy.visit("http://localhost:3000/");
+    cy.get("#email").type("danny_de@email.com");
+    cy.get("#password").type("jerseyMikesRox7");
+    cy.get('[data-testid="login-button"]').click();
+  });
 
   it("Should have a clickable button to route you to add a new job application", () => {
     cy.get('[data-cy="jobApplicationBtn"]').click();
@@ -181,4 +177,56 @@ describe('Dash Board after loggging in with zero recent jobs, contacts and compa
     cy.get('[data-cy="companyBtn"]').click();
     cy.url().should('include', 'http://localhost:3000/companies/new');
   });
-})
+
+  it("should render all 'Add new' buttons when there are no resources", () => {
+    cy.fixture("mockDashBoardNoJobsContactsOrCompanies").then((data) => {
+      data.jobApplications = [];
+      data.contacts = [];
+      data.companies = [];
+      
+      cy.intercept("GET", "**/api/v1/users/1/dashboard", {
+        statusCode: 200,
+        body: data,
+      }).as("getDashboardData");
+    });
+  
+    cy.reload();
+    cy.wait("@getDashboardData");
+  
+    cy.get('[data-cy="jobApplicationBtn"]').should("exist").and("have.text", "Add new job application");
+    cy.get('[data-cy="contactBtn"]').should("exist").and("have.text", "Add new contact");
+    cy.get('[data-cy="companyBtn"]').should("exist").and("have.text", "Add new company");
+  });
+
+  it("should keep all 'Add new' buttons visible when one resource has data", () => {
+    cy.intercept("GET", "**/api/v1/users/1/dashboard", {
+      jobApplications: [{ id: 1, title: "Software Engineer" }],
+      contacts: [],
+      companies: [],
+    }).as("getDashboardData");
+  
+    cy.reload();
+    cy.wait("@getDashboardData");
+  
+    cy.get('[data-cy="jobBtn"]').should("exist").and("have.text", "Add new Job");
+    cy.get('[data-cy="contactBtn"]').should("exist").and("have.text", "Add new Contact");
+    cy.get('[data-cy="companyBtn"]').should("exist").and("have.text", "Add new Company");
+  });
+
+  it("should not render any buttons when all sections have data", () => {
+    cy.fixture("mockDashBoardNoJobsContactsOrCompanies").then((data) => {
+      const modifiedData = { ...data, jobApplications: [{ id: 1 }], contacts: [{ id: 1 }], companies: [{ id: 1 }] };
+      cy.intercept("GET", "**/api/v1/users/1/dashboard", {
+        statusCode: 200,
+        body: modifiedData
+      }).as("getDashboardData");
+    });
+
+    cy.reload();
+    cy.wait("@getDashboardData");
+    cy.get('[data-cy="jobBtn"]').should("not.exist");
+    cy.get('[data-cy="contactBtn"]').should("not.exist");
+    cy.get('[data-cy="companyBtn"]').should("not.exist");
+  });
+
+});

--- a/cypress/fixtures/mockDashBoardSingleJobData.json
+++ b/cypress/fixtures/mockDashBoardSingleJobData.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "id": "1",
+    "type": "dashboard",
+    "attributes": {
+      "id": 1,
+      "name": "Danny DeVito",
+      "email": "danny_de@email.com",
+      "dashboard": {
+        "weekly_summary": {
+          "job_applications": [
+            {
+              "id": 1,
+              "position_title": "Jr. CTO",
+              "date_applied": "2024-10-31",
+              "status": 1,
+              "notes": "Fingers crossed!",
+              "job_description": "Looking for Turing grad/jr dev to be CTO",
+              "application_url": "www.example.com",
+              "created_at": "2024-12-16T21:16:09.601Z",
+              "updated_at": "2024-12-16T21:16:09.601Z",
+              "company_id": 1,
+              "user_id": 1
+            }
+          ],
+          "contacts": [
+          ],
+          "companies": [
+          ]
+        }
+      }
+    }
+  }
+}

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -41,19 +41,20 @@ export const DashBoard : React.FC = () => {
             </label></>
         }
 
-    const ConditionallyRenderBtn: React.FC<CountProps> = ({ section, sectionCount, sectionUrl }) => {
-        if (sectionCount === 0) {
-            return (
-                <Link
-                    className="text-center block text-[20px] font-bold bg-cyan-600 mt-1 w-[16vw] text-white ml-[3vh]"
-                    to={`${sectionUrl}`}
-                >
-                    Add new {section}
-                </Link>
-            );
-        }
-        return <div></div>;
-    };
+        const ConditionallyRenderBtn: React.FC<{ section: string; sectionUrl: string }> = ({ section, sectionUrl }) => {
+
+            if (jobApplicationsCount === 0 || contactsCount === 0 || companiesCount === 0) {
+                return (
+                    <Link
+                        className="text-center block text-[20px] font-bold bg-cyan-600 mt-1 w-[16vw] text-white ml-[3vh]"
+                        to={`${sectionUrl}`}
+                    >
+                        Add new {section}
+                    </Link>
+                );
+            }
+            return null; 
+        };
 
     if(token && isLoggedIn){
         return (
@@ -89,17 +90,17 @@ export const DashBoard : React.FC = () => {
                     <div className="inline-flex space-x-4">
                         <div>
                             <button data-cy="jobApplicationBtn">
-                                <ConditionallyRenderBtn section="job application" sectionCount={jobApplicationsCount} sectionUrl="/jobapplications/new" />
+                                <ConditionallyRenderBtn section="job application" sectionUrl="/jobapplications/new" />
                             </button>
                         </div>
                         <div >
                             <button data-cy="contactBtn">
-                                <ConditionallyRenderBtn sectionCount={contactsCount}  section="contact" sectionUrl="/contacts/new" />
+                                <ConditionallyRenderBtn section="contact" sectionUrl="/contacts/new" />
                             </button>
                         </div>
                         <div>
                             <button data-cy="companyBtn">
-                                <ConditionallyRenderBtn section="company" sectionCount={companiesCount} sectionUrl="/companies/new" />
+                                <ConditionallyRenderBtn section="company" sectionUrl="/companies/new" />
                             </button>
                         </div>
                     </div>

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -41,17 +41,16 @@ export const DashBoard : React.FC = () => {
             </label></>
         }
 
-        const ConditionallyRenderBtn: React.FC<{ section: string; sectionUrl: string }> = ({ section, sectionUrl }) => {
-
-            if (jobApplicationsCount === 0 || contactsCount === 0 || companiesCount === 0) {
-                return (
-                    <Link
-                        className="text-center block text-[20px] font-bold bg-cyan-600 mt-1 w-[16vw] text-white ml-[3vh]"
-                        to={`${sectionUrl}`}
-                    >
-                        Add new {section}
-                    </Link>
-                );
+    const ConditionallyRenderBtn: React.FC<{ section: string; sectionUrl: string }> = ({ section, sectionUrl }) => {
+        if (jobApplicationsCount === 0 || contactsCount === 0 || companiesCount === 0) {
+            return (
+                <Link
+                  className="text-center block text-[20px] font-bold bg-cyan-600 mt-1 w-[16vw] text-white ml-[3vh]"
+                  to={`${sectionUrl}`}
+                >
+                  Add new {section}
+                </Link>
+              );
             }
             return null; 
         };


### PR DESCRIPTION
### Type of Change
- [x] refactor 🧑‍💻
- [x] testing 🧪

### Description
This PR includes a refactor of the dashboard logic to ensure that “Add new” buttons for job applications, contacts, and companies remain visible until all three resources contain data. Additionally, it introduces three Cypress tests to validate this behavior.

### Share the reason(s) for this pull request
This refactor ensures that the “Add new” buttons for jobs, contacts, and companies remain visible until the user has added at least one of each resource, preventing confusion and improving the user experience. Previously, the buttons disappeared as soon as any single resource had data, making it unclear how to add missing information. Now, users can gradually build their dashboard without losing access to necessary actions.

### What questions do you have/what do you want feedback on?
I did struggle with my cypress testing so any feedback on my structure of tests where I put them and if I am using fixture files correctly. 

### Related Tickets
Closes #157 https://github.com/orgs/turingschool/projects/15?pane=issue&itemId=99910631&issue=turingschool%7Ctracker-crm%7C157

### Screenshots (if appllicable):
Shows all "Add New" buttons while a resource is still at 0:

<img width="1710" alt="Screenshot 2025-04-01 at 12 21 03 PM" src="https://github.com/user-attachments/assets/202b9777-85f2-4ee0-b540-0fd96df1e8df" />

All "Add New" buttons are not visible once all resources have at least 1 data entry:

<img width="1709" alt="Screenshot 2025-04-01 at 12 21 47 PM" src="https://github.com/user-attachments/assets/f1d3a09c-980f-40d4-95ef-c1e2db2a2133" />

### Added Test?
- [x] Yes 🫡
  Integration(FE) tests 

### Checklist:
- [x] My code follows the code style of this project.
- [x] All tests (previous and new) pass 🥳


### How to QA this change:
Log in on local, direct to dashboard page. Add data entry for each resource seeing that buttons stay until you have added at least 1 data entry to each of the three resources. 
