### PR TITLE
Bug/uncover buttons from scrollbar

### DIFF
--- a/cypress/e2e/ShowContactSpec.cy.js
+++ b/cypress/e2e/ShowContactSpec.cy.js
@@ -577,7 +577,7 @@ describe("Edit Contact Modal", () => {
 
   it("Should close the edit modal when clicking the X button", () => {
     cy.get('[data-testid="edit-button"]').click();
-    cy.get(".absolute.top-2.right-2").click({ force: true });
+    cy.get('[aria-label="Close modal"]').click();
     cy.get(".bg-white").should("not.exist");
   });
 

--- a/cypress/e2e/editContact.cy.js
+++ b/cypress/e2e/editContact.cy.js
@@ -35,7 +35,7 @@ describe("Edit Contact Functionality", () => {
         ],
       },
       headers: { "Content-Type": "application/json" },
-    }).as("get-contacts");
+    }).as("getContacts");
 
     cy.intercept("GET", "http://localhost:3001/api/v1/users/2/contacts/1", {
       statusCode: 200,
@@ -91,9 +91,11 @@ describe("Edit Contact Functionality", () => {
 
     cy.get('[data-testid="contacts-iconD"]').click();
     cy.url().should("include", "/contacts");
+    cy.wait("@getContacts");
 
     cy.get("table tbody tr").first().click();
     cy.url().should("include", "/contacts/1");
+    cy.wait("@get-contact-details");
   });
 
   it("Should open the edit modal when clicking the Edit button", () => {

--- a/cypress/e2e/editContact.cy.js
+++ b/cypress/e2e/editContact.cy.js
@@ -128,7 +128,7 @@ describe("Edit Contact Functionality", () => {
 
   it("Should close the modal when clicking the X button", () => {
     cy.get("button").contains("Edit").click();
-    cy.get(".absolute.top-2.right-2").click({ force: true });
+    cy.get('[aria-label="Close modal"]').click();
     cy.get(".bg-white").should("not.exist");
   });
 

--- a/cypress/e2e/newContactSpec.cy.js
+++ b/cypress/e2e/newContactSpec.cy.js
@@ -354,22 +354,36 @@ describe("New Contacts page after logging in", () => {
     });
 
     it("Should not be able to create a new company with the same name", () => {
-      cy.intercept("POST", "http://localhost:3001/api/v1/users/2/companies", {
-        statusCode: 422,
+      cy.intercept("GET", "http://localhost:3001/api/v1/users/2/companies", {
+        statusCode: 200,
         body: {
-          error: "A company with this name already exists.",
+          data: [
+            {
+              id: 1,
+              attributes: {
+                name: "Company A",
+                website: "example.com",
+                street_address: "123 Main St",
+                city: "Denver",
+                state: "CO",
+                zip_code: "80202",
+                notes: "Test company",
+              },
+            },
+          ],
         },
-      }).as("duplicateCompany");
+      }).as("getCompanies");
 
       cy.get("a > .bg-cyan-600").click();
       cy.contains("button", "Add new company").click();
+      cy.wait("@getCompanies");
 
       cy.get("#companyName").type("Company A");
       cy.get(".max-w-4xl")
         .find("button[type='submit']")
         .click();
-      cy.get('[aria-label="Close modal"]').click();
-      cy.get(".text-red-500").should(
+
+      cy.get('[data-testid="company-error"]').should(
         "contain.text",
         "A company with this name already exists."
       );
@@ -390,6 +404,6 @@ describe("New Contacts page after logging in", () => {
       cy.get("label").contains("State:").should("exist");
       cy.get("label").contains("Zip Code:").should("exist");
       cy.get("label").contains("Notes:").should("exist");
-    })
+    });
   });
 });

--- a/cypress/e2e/newContactSpec.cy.js
+++ b/cypress/e2e/newContactSpec.cy.js
@@ -51,24 +51,28 @@ describe("New Contacts page after logging in", () => {
       },
     }).as("getCompanies");
 
-    cy.intercept("POST", `http://localhost:3001/api/v1/users/2/companies`, {
-      statusCode: 201,
-      body: {
-        data: {
-          id: 3,
-          type: "company",
-          attributes: {
-            name: "Company 123",
-            website: "www.testcompany.com",
-            street_address: "123 Test St",
-            city: "Test City",
-            state: "CO",
-            zip_code: "80237",
-            notes: "Test notes",
+    cy.intercept(
+      "POST",
+      `http://localhost:3001/api/v1/users/2/companies`,
+      {
+        statusCode: 201,
+        body: {
+          data: {
+            id: 3,
+            type: "company",
+            attributes: {
+              name: "Company 123",
+              website: "www.testcompany.com",
+              street_address: "123 Test St",
+              city: "Test City",
+              state: "CO",
+              zip_code: "80237",
+              notes: "Test notes",
+            },
           },
         },
-      },
-    }).as("addCompany");
+      }
+    ).as("addCompany");
 
     cy.visit("http://localhost:3000/contacts");
     cy.get("#email").type("dollyP@email.com");
@@ -226,8 +230,6 @@ describe("New Contacts page after logging in", () => {
       cy.get("#companyName").type("Company Placeholder");
       cy.get(".max-w-4xl")
         .find("button[type='submit']")
-        .scrollIntoView()
-        .should("be.visible")
         .click();
       cy.wait("@addCompany");
 
@@ -365,13 +367,12 @@ describe("New Contacts page after logging in", () => {
       cy.get("#companyName").type("Company A");
       cy.get(".max-w-4xl")
         .find("button[type='submit']")
-        .scrollIntoView()
         .click();
       cy.get(".text-red-500").should(
         "contain.text",
         "A company with this name already exists."
       );
-      cy.contains("button", "X").scrollIntoView().click({ force: true });
+      cy.get('[aria-label="Close modal"]').click();
     });
 
     it("Should keep the add company modal open when clicked", () => {

--- a/cypress/e2e/newContactSpec.cy.js
+++ b/cypress/e2e/newContactSpec.cy.js
@@ -368,11 +368,11 @@ describe("New Contacts page after logging in", () => {
       cy.get(".max-w-4xl")
         .find("button[type='submit']")
         .click();
+      cy.get('[aria-label="Close modal"]').click();
       cy.get(".text-red-500").should(
         "contain.text",
         "A company with this name already exists."
       );
-      cy.get('[aria-label="Close modal"]').click();
     });
 
     it("Should keep the add company modal open when clicked", () => {

--- a/src/components/companies/NewCompany.tsx
+++ b/src/components/companies/NewCompany.tsx
@@ -158,9 +158,15 @@ function NewCompany({ isModal, onSuccess }: NewCompanyProps) {
               className="p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-cyan-500"
               required
             />
-            {errors.name && <p className="text-red-500 mt-1">{errors.name}</p>}
+            {errors.name && (
+              <p className="text-red-500" data-testid="company-error">
+                {errors.name}
+              </p>
+            )}
             {errors.duplicate && (
-              <p className="text-red-500 mt-1">{errors.duplicate}</p>
+              <p className="text-red-500" data-testid="company-error">
+                {errors.duplicate}
+              </p>
             )}
           </div>
           <div className="flex flex-col">

--- a/src/components/contacts/CompanyModal.tsx
+++ b/src/components/contacts/CompanyModal.tsx
@@ -27,10 +27,10 @@ const CompanyModal: React.FC<CompanyModalProps> = ({
       onClick={() => setIsOpen(false)}
     >
       <div
-        className="bg-white p-6 rounded-lg shadow-lg w-[50vw] max-h-[90vh] relative"
+        className="bg-white p-6 rounded-lg shadow-lg w-[50vw] max-h-[90vh]"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="absolute top-2 right-8 z-50">
+        <div className="flex justify-end mb-2">
           <button
             onClick={() => setIsOpen(false)}
             className="bg-white p-2 rounded-full text-gray-600 hover:text-gray-900 hover:bg-gray-100 shadow-sm"
@@ -39,7 +39,8 @@ const CompanyModal: React.FC<CompanyModalProps> = ({
             X
           </button>
         </div>
-        <div className="overflow-y-auto max-h-[calc(90vh-4rem)] pr-8 mt-4">
+        <div className="overflow-y-auto max-h-[calc(90vh-4rem)] pr-8">
+          <h2 className="text-xl font-bold text-cyan-600 mb-4">New Company</h2>
           <NewCompany isModal={true} onSuccess={handleNewCompany} />
         </div>
       </div>

--- a/src/components/contacts/CompanyModal.tsx
+++ b/src/components/contacts/CompanyModal.tsx
@@ -27,16 +27,21 @@ const CompanyModal: React.FC<CompanyModalProps> = ({
       onClick={() => setIsOpen(false)}
     >
       <div
-        className="bg-white p-6 rounded-lg shadow-lg w-[50vw] max-h-[100vh] overflow-y-auto relative"
+        className="bg-white p-6 rounded-lg shadow-lg w-[50vw] max-h-[90vh] relative"
         onClick={(e) => e.stopPropagation()}
       >
-        <button
-          onClick={() => setIsOpen(false)}
-          className="absolute top-2 right-2 text-gray-600 hover:text-gray-900"
-        >
-          X
-        </button>
-        <NewCompany isModal={true} onSuccess={handleNewCompany} />
+        <div className="absolute top-2 right-8 z-50">
+          <button
+            onClick={() => setIsOpen(false)}
+            className="bg-white p-2 rounded-full text-gray-600 hover:text-gray-900 hover:bg-gray-100 shadow-sm"
+            aria-label="Close modal"
+          >
+            X
+          </button>
+        </div>
+        <div className="overflow-y-auto max-h-[calc(90vh-4rem)] pr-8 mt-4">
+          <NewCompany isModal={true} onSuccess={handleNewCompany} />
+        </div>
       </div>
     </div>
   );

--- a/src/components/contacts/EditContactModal.tsx
+++ b/src/components/contacts/EditContactModal.tsx
@@ -106,97 +106,102 @@ const EditContactModal: React.FC<EditContactModalProps> = ({
       onClick={() => setIsOpen(false)}
     >
       <div
-        className="bg-white p-6 rounded-lg shadow-lg w-[40vw] max-h-[90vh] overflow-y-auto relative"
+        className="bg-white p-6 rounded-lg shadow-lg w-[50vw] max-h-[90vh] relative"
         onClick={(e) => e.stopPropagation()}
       >
-        <button
-          onClick={() => setIsOpen(false)}
-          className="absolute top-2 right-2 text-gray-600 hover:text-gray-900"
-        >
-          X
-        </button>
-        <h2 className="text-xl font-bold text-cyan-600 mb-4">Edit Contact</h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-gray-700 font-medium mb-1">
-              First Name <span className="text-red-600">*</span>
-            </label>
-            <input
-              type="text"
-              name="firstName"
-              value={formData.firstName}
-              onChange={handleInputChange}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-cyan-500"
-              required
-            />
-          </div>
+        <div className="absolute top-2 right-8 z-50">
+          <button
+            onClick={() => setIsOpen(false)}
+            className="bg-white p-2 rounded-full text-gray-600 hover:text-gray-900 hover:bg-gray-100 shadow-sm"
+            aria-label="Close modal"
+          >
+            X
+          </button>
+        </div>
+        <div className="overflow-y-auto max-h-[calc(90vh-4rem)] pr-8 mt-4">
+          <h2 className="text-xl font-bold text-cyan-600 mb-4">Edit Contact</h2>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-gray-700 font-medium mb-1">
+                First Name <span className="text-red-600">*</span>
+              </label>
+              <input
+                type="text"
+                name="firstName"
+                value={formData.firstName}
+                onChange={handleInputChange}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-cyan-500"
+                required
+              />
+            </div>
 
-          <div>
-            <label className="block text-gray-700 font-medium mb-1">
-              Last Name <span className="text-red-600">*</span>
-            </label>
-            <input
-              type="text"
-              name="lastName"
-              value={formData.lastName}
-              onChange={handleInputChange}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-cyan-500"
-              required
-            />
-          </div>
+            <div>
+              <label className="block text-gray-700 font-medium mb-1">
+                Last Name <span className="text-red-600">*</span>
+              </label>
+              <input
+                type="text"
+                name="lastName"
+                value={formData.lastName}
+                onChange={handleInputChange}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-cyan-500"
+                required
+              />
+            </div>
 
-          <div>
-            <label className="block text-gray-700 font-medium mb-1">
-              Email
-            </label>
-            <input
-              type="email"
-              name="email"
-              value={formData.email}
-              onChange={handleInputChange}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-cyan-500"
-            />
-          </div>
+            <div>
+              <label className="block text-gray-700 font-medium mb-1">
+                Email
+              </label>
+              <input
+                type="email"
+                name="email"
+                value={formData.email}
+                onChange={handleInputChange}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-cyan-500"
+              />
+            </div>
 
-          <div>
-            <label className="block text-gray-700 font-medium mb-1">
-              Phone Number
-            </label>
-            <input
-              type="text"
-              name="phoneNumber"
-              value={formData.phoneNumber}
-              onChange={handleInputChange}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-cyan-500"
-            />
-          </div>
+            <div>
+              <label className="block text-gray-700 font-medium mb-1">
+                Phone Number
+              </label>
+              <input
+                type="text"
+                name="phoneNumber"
+                value={formData.phoneNumber}
+                onChange={handleInputChange}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-cyan-500"
+              />
+            </div>
 
-          <div>
-            <label className="block text-gray-700 font-medium mb-1">
-              Notes
-            </label>
-            <textarea
-              name="notes"
-              value={formData.notes}
-              onChange={handleInputChange}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-cyan-500"
-              rows={3}
-            />
-          </div>
-          {errorMessage && (
-            <p className="error text-red-600 mt-2" data-testid="error-message">
-              {errorMessage}
-            </p>
-          )}
-          <div className="flex justify-end">
-            <button
-              type="submit"
-              className="bg-cyan-600 text-white px-4 py-2 rounded hover:bg-cyan-500"
-            >
-              Save
-            </button>
-          </div>
-        </form>
+            <div>
+              <label className="block text-gray-700 font-medium mb-1">
+                Notes
+              </label>
+              <textarea
+                name="notes"
+                value={formData.notes}
+                onChange={handleInputChange}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-cyan-500"
+                rows={3}
+              />
+            </div>
+            {errorMessage && (
+              <p className="error text-red-600 mt-2" data-testid="error-message">
+                {errorMessage}
+              </p>
+            )}
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="bg-cyan-600 text-white px-4 py-2 rounded hover:bg-cyan-500"
+              >
+                Save
+              </button>
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/src/components/contacts/EditContactModal.tsx
+++ b/src/components/contacts/EditContactModal.tsx
@@ -106,10 +106,10 @@ const EditContactModal: React.FC<EditContactModalProps> = ({
       onClick={() => setIsOpen(false)}
     >
       <div
-        className="bg-white p-6 rounded-lg shadow-lg w-[50vw] max-h-[90vh] relative"
+        className="bg-white p-6 rounded-lg shadow-lg w-[50vw] max-h-[90vh]"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="absolute top-2 right-8 z-50">
+        <div className="flex justify-end mb-2">
           <button
             onClick={() => setIsOpen(false)}
             className="bg-white p-2 rounded-full text-gray-600 hover:text-gray-900 hover:bg-gray-100 shadow-sm"
@@ -118,7 +118,7 @@ const EditContactModal: React.FC<EditContactModalProps> = ({
             X
           </button>
         </div>
-        <div className="overflow-y-auto max-h-[calc(90vh-4rem)] pr-8 mt-4">
+        <div className="overflow-y-auto max-h-[calc(90vh-4rem)] pr-8">
           <h2 className="text-xl font-bold text-cyan-600 mb-4">Edit Contact</h2>
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>


### PR DESCRIPTION
### Type of Change
- [ ] feature ⛲
- [x] bug fix 🐛
- [ ] documentation update 📃
- [x] styling 🎨
- [ ] refactor 🧑‍💻
- [x] testing 🧪
<!--- Delete any above that do not apply to this PR -->

### Description
This PR fixes modal layouts in the Edit Contact components to ensure the close button is always accessible and updates Cypress tests to use aria-labels.

### Share the reason(s) for this pull request
- Exit button getting obscured by scroll bar in Edit Contact form window.
- Tests were using force clicks, which didn't reflect real user behavior

### What questions do you have/what do you want feedback on?
The exit button is no longer obscured by the scroll bar, but I was having trouble getting it right justified properly. Thoughts on the position of the button?

### Added Test?
- [x] Yes 🫡
  -Just a test revision.
- [ ] No 🙅


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] All tests (previous and new) pass 🥳
<!--- Delete any above that do not apply to this PR -->

### How to QA this change:
- Navigate to the edit contact page. Shrink window until  the scroll bar appears and make sure the exit button does not get covered by the scroll bar.
