### PR TITLE
NewCompany.tsx return Select State option changed to a map over the s…

### DIFF
--- a/src/pages/Companies/components/NewCompany.tsx
+++ b/src/pages/Companies/components/NewCompany.tsx
@@ -5,6 +5,7 @@ import { CompanyAttributes } from "../../../constants/Interfaces";
 import { useUserLoggedContext } from "../../../context/UserLoggedContext";
 import { useErrorContext } from "../../../context/ErrorContext"; 
 import TipTap from '../../../wysiwyg/TipTap';
+import US_STATES from "../../../constants/states";
 
 interface NewCompanyProps {
   isModal?: boolean;
@@ -211,56 +212,11 @@ function NewCompany({ isModal, onSuccess }: NewCompanyProps) {
               className="p-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-cyan-500"
             >
               <option value="">Select State</option>
-              <option value="AL">Alabama</option>
-              <option value="AK">Alaska</option>
-              <option value="AZ">Arizona</option>
-              <option value="AR">Arkansas</option>
-              <option value="CA">California</option>
-              <option value="CO">Colorado</option>
-              <option value="CT">Connecticut</option>
-              <option value="DE">Delaware</option>
-              <option value="FL">Florida</option>
-              <option value="GA">Georgia</option>
-              <option value="HI">Hawaii</option>
-              <option value="ID">Idaho</option>
-              <option value="IL">Illinois</option>
-              <option value="IN">Indiana</option>
-              <option value="IA">Iowa</option>
-              <option value="KS">Kansas</option>
-              <option value="KY">Kentucky</option>
-              <option value="LA">Louisiana</option>
-              <option value="ME">Maine</option>
-              <option value="MD">Maryland</option>
-              <option value="MA">Massachusetts</option>
-              <option value="MI">Michigan</option>
-              <option value="MN">Minnesota</option>
-              <option value="MS">Mississippi</option>
-              <option value="MO">Missouri</option>
-              <option value="MT">Montana</option>
-              <option value="NE">Nebraska</option>
-              <option value="NV">Nevada</option>
-              <option value="NH">New Hampshire</option>
-              <option value="NJ">New Jersey</option>
-              <option value="NM">New Mexico</option>
-              <option value="NY">New York</option>
-              <option value="NC">North Carolina</option>
-              <option value="ND">North Dakota</option>
-              <option value="OH">Ohio</option>
-              <option value="OK">Oklahoma</option>
-              <option value="OR">Oregon</option>
-              <option value="PA">Pennsylvania</option>
-              <option value="RI">Rhode Island</option>
-              <option value="SC">South Carolina</option>
-              <option value="SD">South Dakota</option>
-              <option value="TN">Tennessee</option>
-              <option value="TX">Texas</option>
-              <option value="UT">Utah</option>
-              <option value="VT">Vermont</option>
-              <option value="VA">Virginia</option>
-              <option value="WA">Washington</option>
-              <option value="WV">West Virginia</option>
-              <option value="WI">Wisconsin</option>
-              <option value="WY">Wyoming</option>
+              {US_STATES.map(({ code, name }) => (
+                <option key={code} value={code}>
+                  {name}
+                </option>
+              ))}
             </select>
           </div>
           <div className="flex flex-col">


### PR DESCRIPTION
…tates.ts file, removing the hard coded values. Cypress testing still passes. Ready for review

### Type of Change
- [ ] feature ⛲
- [ ] bug fix 🐛
- [ ] documentation update 📃
- [ ] styling 🎨
- [X] refactor 🧑‍💻
- [ ] testing 🧪
<!--- Delete any above that do not apply to this PR -->

### Description
In the return state of the NewCompany.tsx, all the option values for the states had previously been hard coded in. This was changed to use the states.ts file, and the US_STATES variable. Local host still ran and values were available, cypress testing still passed.

### Share the reason(s) for this pull request
Issue ticket asked for a more flexible system here.

### What questions do you have/what do you want feedback on?
Is there any way this can be broken? Are there any values noticed not appearing?

### Related Tickets
Ticket 197, already linked to it

### Screenshots (if applicable):

### Added Test?
- [ ] Yes 🫡
  - <!--- If yes, what type? Integration(FE), Unit/Model or Request/Controller Specs?-->
- [X] No 🙅

<!--- Delete any above that do not apply to this PR -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [X] All tests (previous and new) pass 🥳
<!--- Delete any above that do not apply to this PR -->

### How to QA this change:
<!--- Outline the steps needed to locally verify the implemented changes are working as intended -->

