### PR TITLE
Date Applied Bug

### DIFF
--- a/src/pages/JobApplications/components/NewJobApplication.tsx
+++ b/src/pages/JobApplications/components/NewJobApplication.tsx
@@ -147,7 +147,7 @@ function NewJobApplication() {
               {/* Date Applied */}
               <label className="text-[1vw] font-[Helvetica Neue] flex flex-col w-[45%]">
                 <span className="font-semibold">Date Applied:
-                  <span className="text-red-500"> *</span>
+                {status !== 7 && <span className="text-red-500"> *</span>}
                 </span>
                 <input
                   type="date"
@@ -155,7 +155,7 @@ function NewJobApplication() {
                   value={dateApplied}
                   onChange={(e) => setDateApplied(e.target.value)}
                   className="p-2 border-4 border-slate-800 rounded-lg focus:outline-none focus:ring-2 m-2"
-                  required
+                  required={status !==7}
                 />
               </label>
 


### PR DESCRIPTION

### Type of Change
- [X] bug fix 🐛

### Description
Added conditional to the required section of JobApplication. If status code is 7, or not yet applied, then the date applied is not required. I also removed the red asterisk above date if someone selects 7 as their status. 

### Share the reason(s) for this pull request
A user can now save an application without a date if they haven't yet applied. 

### Screenshots (if applicable):
![9u9cm8](https://github.com/user-attachments/assets/b9c59ff8-e914-4645-9cb5-3ab7b34150a4)

### Added Test?
- [X] No 🙅

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [X] All tests (previous and new) pass 🥳
<!--- Delete any above that do not apply to this PR -->

### How to QA this change:
<!--- Outline the steps needed to locally verify the implemented changes are working as intended -->

