### PR TITLE
CompanyShow notes bugfix

### DIFF
--- a/src/pages/Companies/components/CompanyShow.tsx
+++ b/src/pages/Companies/components/CompanyShow.tsx
@@ -236,7 +236,7 @@ function CompanyShow() {
                 Notes
               </span>
               <p className="text-gray-600 whitespace-pre-wrap">
-                {<HTMLRender htmlString={companyAttributes.notes} />}
+                {<HTMLRender htmlString={companyAttributes.notes || ''} />}
               </p>
             </div>
           </div>


### PR DESCRIPTION
### Type of Change
- [ ] feature ⛲
- [ x ] bug fix 🐛
- [ ] documentation update 📃
- [ ] styling 🎨
- [ ] refactor 🧑‍💻
- [ ] testing 🧪
<!--- Delete any above that do not apply to this PR -->

### Description
<!--- Describe your changes in detail -->
I added a default empty string value to the CompanyShow.tsx component when rendering a Company's notes attribute using the HTMLRender library. 

### Share the reason(s) for this pull request
<!--- Why is this change required? What problem does it solve? -->
Before this change, the whole site would error out when trying to display a company whose notes attribute text was previously deleted by a user--it would pass a null value to HTMLRender instead of an empty string, which is unsupported by the library. Now, a user should be able to see the details for any previously created company even if their notes attribute is empty.

### What questions do you have/what do you want feedback on?
<!--- List any specific questions and feedback requests -->
Let me know if this is related to any other bugs you all have encountered in the codebase--if the HTMLRender library is used anywhere else in the code, it could create the same error for other attribute fields.

### Related Tickets
<!--- example: closes #12 https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

### Screenshots (if applicable):

### Added Test?
- [ ] Yes 🫡
  - <!--- If yes, what type? Integration(FE), Unit/Model or Request/Controller Specs?-->
- [ x ] No 🙅

<!--- Delete any above that do not apply to this PR -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ x ] All tests (previous and new) pass 🥳
<!--- Delete any above that do not apply to this PR -->

### How to QA this change:
<!--- Outline the steps needed to locally verify the implemented changes are working as intended -->
Create a company with some nonsense text in its notes. Then use the edit company function in the CompanyShow view to delete the company's notes text. Then go up one page to the Companies view, and then click on the company whose notes you deleted. You should be taken back to the CompanyShow view, with the notes field displaying as blank without any errors.
